### PR TITLE
Add `copy(::AESBlock)`

### DIFF
--- a/src/types.jl
+++ b/src/types.jl
@@ -110,6 +110,10 @@ function Base.setindex!(block::B, val, i) where {B<:AESBlock}
 	block.data[16*(block.offset - 1) + i] = eltype(block.data)(val)
 end
 
+function Base.copy(block::AESBlock)
+	return AESBlock(copy(block.data), block.offset)
+end
+
 function Base.copyto!(block::B, arr::AbstractArray{T2,1}) where {B<:AESBlock, T2}
 	for i in 1:16
 		block.data[16*(block.offset - 1) + i] = eltype(block.data)(arr[i])

--- a/test/interface.jl
+++ b/test/interface.jl
@@ -1,0 +1,7 @@
+using AES, Test
+
+a=AES.AESBlock(rand(UInt8, 100), 3)
+ac=copy(a)
+@test ac == a
+@test ac !== a
+@test ac isa AES.AESBlock

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 using SafeTestsets
 
 @time begin
+	@time @safetestset "Interface Tests" begin include("interface.jl") end
 	@time @safetestset "Block Encryption/Decryption tests" begin include("blocktest.jl") end
 	@time @safetestset "CBC Mode tests" begin include("cbc.jl") end
 	@time @safetestset "CTR Mode tests" begin include("ctr.jl") end


### PR DESCRIPTION
Either this or an implementation of `unaliascopy` is needed if a proper `dataids` is added, as https://github.com/JuliaLang/julia/pull/26237 proposes. I don't see any reason not to specialize `copy` like this here. (Without this, a `Vector{UInt8}` is returned.)

I didn't know where to add tests. They should probably look something like
```julia
a=AES.AESBlock(rand(UInt8, 100), 3)
ac=copy(a)
@test ac == a
@test ac !== a
@test ac isa AES.AESBlock
```